### PR TITLE
 Support custom package names

### DIFF
--- a/make-rpm.mk
+++ b/make-rpm.mk
@@ -73,7 +73,9 @@ rpm: distcwd
 	rpmbuild --define "VERSION $(VERSION)" --define "RELEASE $(RELEASE)" -ta $(WORKDIR)/$(PKGNAME).tgz
 
 srpm: distcwd
+ifndef NOWIPETREE
 	rpmdev-wipetree
+endif
 	# we need to specify old digest algorithm to support el5
 	rpmbuild $(SRPMOPTIONS) \
 		--define "_source_filedigest_algorithm md5" \

--- a/make-rpm.mk
+++ b/make-rpm.mk
@@ -1,5 +1,7 @@
 # --- Variables ---
+ifndef PKGNAME
 PKGNAME:=$(shell test -f *.spec && basename *.spec .spec)
+endif
 
 # works only on gnu make >= 4.2 :(
 #ifneq ($(.SHELLSTATUS), 0)
@@ -73,7 +75,12 @@ rpm: distcwd
 srpm: distcwd
 	rpmdev-wipetree
 	# we need to specify old digest algorithm to support el5
-	rpmbuild $(SRPMOPTIONS) --define "_source_filedigest_algorithm md5" --define "VERSION $(VERSION)" --define "RELEASE $(RELEASE)" -ts ${WORKDIR}/$(PKGNAME).tgz
+	rpmbuild $(SRPMOPTIONS) \
+		--define "_source_filedigest_algorithm md5" \
+		--define "VERSION $(VERSION)" \
+		--define "RELEASE $(RELEASE)" \
+		--define "PACKAGE_NAME $(PKGNAME)" \
+		-ts ${WORKDIR}/$(PKGNAME).tgz
 
 # Build RPMs for all os versions defined on OS_VERIONS
 # we use three phases (init, chroot, rebuild) to allow user to modify the chrooted system as needed
@@ -94,6 +101,7 @@ rpms: srpm
 	      --define "dist .el$${os_version}" \
 	      --define "VERSION $(VERSION)" \
 	      --define "RELEASE $(RELEASE)" \
+	      --define "PACKAGE_NAME $(PKGNAME)" \
 	      --rebuild \
 	      -r epel-$${os_version}-x86_64 $(MOCKOPTIONS) \
 	      --no-clean \


### PR DESCRIPTION
Allow to override PKGNAME from including makefile.

- You can also disable rpmdev-wipetree to support superuser (root) (e.g. in docker) by defining `NOWIPETREE`

Example of branch based package name:
```
# must be before include
NOWIPETREE=true

-include make-rpm.mk

VCS_ROOT ?= $(strip $(shell git symbolic-ref HEAD))
branch_name := $(subst refs/heads/,,$(VCS_ROOT))
ifneq ($(branch_name), master)
new_pkg_name := $(PKGNAME)-$(branch_name)
PKGNAME=$(new_pkg_name)
endif
```
