### PR TITLE
Add || false to 'rpms' to actually exit on error.

### DIFF
--- a/make-rpm.mk
+++ b/make-rpm.mk
@@ -111,7 +111,8 @@ rpms: srpm
 	      -r epel-$${os_version}-x86_64 $(MOCKOPTIONS) \
 	      --no-clean \
 	      --no-cleanup-after \
-	      $(SRPMDIR)/*.src.rpm; \
+	      $(SRPMDIR)/*.src.rpm || \
+	    false; \
 	done
 
 # Upload RPMs for all os versions to Sonatype Nexus


### PR DESCRIPTION
https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html:
"Even with set -e, the shell does not exit if the command that fails is part of any command executed in a && or || list except the command following the final && or ||."