### PR TITLE
Issue 18 deploy path fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ mkplugin:
 3. (if you like it) git add mkplugin.mk && git commit mkplugin.mk && git push 
 
 
-Some examples what it can do
-----------------------------
+Some examples of what it can do
+-------------------------------
 
 Create rpm from content in current working directory
 ```
@@ -34,9 +34,9 @@ make rpms
 Upload to artifact repository. This will also build the rpms before.
 (Note: https://pypi.python.org/pypi/repositorytools >=4.2.1 are needed)
 ```
-REPOSITORY_URL=https://repository.eng.mycompany.com
-REPOSITORY_USER=jdoe
-REPOSITORY_PASSWORD=mysecretpassword
+export REPOSITORY_URL=https://repository.eng.mycompany.com
+export REPOSITORY_USER=jdoe
+export REPOSITORY_PASSWORD=mysecretpassword
 
 make uploadrpms GROUP=com.mycompany
 ```
@@ -85,7 +85,7 @@ Upload configuration
 
 You need to install *repositorytools* of version 4.2.1 or higher for upload
 to Nexus repository manager to work. The *repositorytools* can be found at
-https://pypi.python.org/pypi/repositorytools.
+https://pypi.org/project/repositorytools/.
 
 
 ### Connection to the repository manager
@@ -98,9 +98,9 @@ The `REPOSITORY_URL` variable must contain URL to the Nexus service, not
 to a specific repository.
 
 ```
-REPOSITORY_URL=https://repository.eng.mycompany.com
-REPOSITORY_USER=jdoe
-REPOSITORY_PASSWORD=mysecretpassword
+export REPOSITORY_URL=https://repository.eng.mycompany.com
+export REPOSITORY_USER=jdoe
+export REPOSITORY_PASSWORD=mysecretpassword
 
 make uploadrpms GROUP=com.mycompany
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,12 @@ cd /vagrant
 sudo yum -y install mock rpm-build rpmdevtools bats
 sudo usermod -a -G mock vagrant
 
+umask 022
+curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
+sudo python /tmp/get-pip.py && \
+pip install repositorytools
+rm -f /tmp/get-pip.py
+
 echo "Provisioning done."
 SCRIPT
 

--- a/make-rpm.mk
+++ b/make-rpm.mk
@@ -20,7 +20,7 @@ VERSION?=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUGFIX)
 GROUP?=com.example# used when uploading to artifact repository
 WORKDIR:=/tmp/
 RELEASE ?= 1
-BUILDARCH=$(shell grep -oP '(?<=^BuildArch:\s).*' $(PKGNAME).spec)
+BUILDARCH=$(shell grep -oP '(?<=^BuildArch:\s).*' $(PKGNAME).spec || rpm --eval %{_arch})
 RPMDIR=$(shell rpm --eval %{_rpmdir})
 prefix=$(DESTDIR)$(shell rpm --eval %{_prefix})
 bindir=$(DESTDIR)$(shell rpm --eval %{_bindir})
@@ -119,7 +119,7 @@ rpms: srpm
 # Requires package repository-tools
 uploadrpms: rpms
 	$(foreach os_version, $(OS_VERSIONS), \
-	    artifact upload $(UPLOAD_EXTRA_PARAMS) --artifact $(PKGNAME) --version $(VERSION)-$(RELEASE) \
+	    artifact upload $(UPLOAD_EXTRA_PARAMS) --artifact $(PKGNAME) --version $(VERSION)-$(RELEASE).el$(os_version).$(BUILDARCH) \
 	      $(UPLOAD_OPTIONS) \
 	      $(RESULTDIR)/$(os_version)/$(PKGNAME)-$(VERSION)-*$(BUILDARCH).rpm \
 	      $(UPLOAD_REPOSITORY) \

--- a/make-rpm.mk
+++ b/make-rpm.mk
@@ -1,7 +1,5 @@
 # --- Variables ---
-ifndef PKGNAME
-PKGNAME:=$(shell test -f *.spec && basename *.spec .spec)
-endif
+PKGNAME ?= $(shell test -f *.spec && basename *.spec .spec)
 
 # works only on gnu make >= 4.2 :(
 #ifneq ($(.SHELLSTATUS), 0)


### PR DESCRIPTION
This pull request contains:

* Fix for issue #17.
* Fix for issue #18 - it adds `.el$(os_version).$(BUILDARCH)` to version part of deploy path and also detects default build architecture if it is not specified explicitely in the spec file.
* Minor updates to the documentation, esp. URL of repositorytools on PYPI.
* Update to Vagrantfile that will provision the box with pip and repositorytools already installed.